### PR TITLE
Custom data annotation to validate password in user model

### DIFF
--- a/Api/Models/User.cs
+++ b/Api/Models/User.cs
@@ -1,6 +1,7 @@
 #pragma warning disable 8618
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.RegularExpressions;
 using MyApp.Models;
 
 namespace TeamFive.Models;
@@ -8,18 +9,41 @@ public class User : BaseEntity
 {
     [Required]
     public string FirstName { get; set; }
+
     [Required]
     public string LastName { get; set; }
+
     [Required]
     [EmailAddress]
     public string Email { get; set; }
+
     [Required]
     [MinLength(8)]
-    public string Password { get; set;  }
+    [StrongPassword]
+    public string Password { get; set; }
+
     [NotMapped]
     [Compare("Password")]
     public string Confirm { get; set; }
 
     //Associations
     public ICollection<RefreshToken> RefreshTokens = new List<RefreshToken>();
+
+    // Custom validation
+    public class StrongPasswordAttribute : ValidationAttribute
+    {
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+        {
+            string pattern = @"^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*\W).+$";
+
+            if (Regex.IsMatch(value.ToString(), pattern))
+            {
+                return ValidationResult.Success;
+            }
+            else
+            {
+                return new ValidationResult("Your password must include at least 1 of each of the following: Uppercase letter, lowercase letter, number, and special character");
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Completes

Link to trello ticket or a brief description.
https://trello.com/c/KOpOqCVi

### Checklist

- [X] I have tested my changes.
- [X] I have updated the documentation if necessary.

## What Did you do to test this feature?

Please use this space to briefly state what you did to test this.  
Example: I tested the route with Postman and it returned this object:
```
{
    userId: 1
    name: User1,
    email: user1@gmail.com,
}
```

I put the following into Postman (POST request at /api/auth/register):
```
{
	"FirstName":"Jane",
	"LastName": "Doe",
	"Email": "example@mail.com",
	"Password":"Passwooord1",
	"Confirm": "Passwooord1"
}
```
The result included the error from my custom data annotation:
```
{
    "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
    "title": "One or more validation errors occurred.",
    "status": 400,
    "traceId": "00-11496dbc5747c0e7c93d4bec7c9a093c-eca20e7b8c2f763d-00",
    "errors": {
        "Password": [
            "Your password must include at least 1 of each of the following: Uppercase letter, lowercase letter, number, and special character"
        ]
    }
}
```
When I added a special character to the end of the password, I got the following:
```
{
    "id": 2,
    "firstName": "Jane",
    "lastName": "Doe",
    "email": "example@mail.com"
}
```
