### PR TITLE
Remove unnecessary React imports from components

### DIFF
--- a/Client/src/Components/Example.jsx
+++ b/Client/src/Components/Example.jsx
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 const Example = () => {
   const [hello, setHello] = useState("");

--- a/Client/src/Components/Footer.jsx
+++ b/Client/src/Components/Footer.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import instrumentalImage from '../Assets/Images/instrumentalImage.jpg'
 
 const Footer = () => {

--- a/Client/src/Components/Instrument.jsx
+++ b/Client/src/Components/Instrument.jsx
@@ -1,4 +1,4 @@
-import React, { useState,useEffect } from 'react'
+import { useState,useEffect } from 'react'
 import axios from 'axios';
 
 function InstrumentComponent() {

--- a/Client/src/Components/InstrumentLessonsOffered.jsx
+++ b/Client/src/Components/InstrumentLessonsOffered.jsx
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 const InstrumentLessonsOffered = () => {

--- a/Client/src/Components/LandingPage.jsx
+++ b/Client/src/Components/LandingPage.jsx
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 const Example = () => {
   const [hello, setHello] = useState("");

--- a/Client/src/Components/Login.jsx
+++ b/Client/src/Components/Login.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import useLocalStorage from '../Hooks/useLocalStorage';
 import { useNavigate, Link as RouterLink } from 'react-router-dom';
 import axios from 'axios';

--- a/Client/src/Components/NavBar.jsx
+++ b/Client/src/Components/NavBar.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
 
 const NavBar = () => {

--- a/Client/src/Components/Register.jsx
+++ b/Client/src/Components/Register.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import useLocalStorage from '../Hooks/useLocalStorage';
 import { useNavigate, Link as RouterLink } from 'react-router-dom';
 import axios from 'axios';


### PR DESCRIPTION
### Completes

Just a move to clean up the code base. There's no need to explicitly import the React module in files that contain React components.

### Checklist

- [x] I have tested my changes.
- [ ] I have updated the documentation if necessary.

## What Did you do to test this feature?

_N/A_