### PR TITLE
Lesson list by Id now returns Start and End fields

### DIFF
--- a/Api/Controllers/AuthController.cs
+++ b/Api/Controllers/AuthController.cs
@@ -57,7 +57,6 @@ public class AuthController : ControllerBase
         }
 
         UserWithRoleDto? validUser = await _userService.ValidateUserPasswordAsync(loginUser);
-        Console.WriteLine(validUser.Role);
         if (validUser == null)
         {
             ModelState.AddModelError("email", "Invalid email or password");

--- a/Api/Controllers/LessonController.cs
+++ b/Api/Controllers/LessonController.cs
@@ -78,12 +78,8 @@ public class LessonController : ControllerBase
         {
             return BadRequest("Something went wrong when booking the lesson");
         }
-        Console.WriteLine("_+_+_+_+_+_" + createdLesson + "+_+_+_+_+_+_+_");
-
         try
         {
-            Console.WriteLine("_+_+_+_+_+_" + createdLesson + "+_+_+_+_+_+_+_");
-
             return CreatedAtAction(nameof(OneLesson),new {id= createdLesson.LessonId}, createdLesson);
         }
         catch (Exception ex)
@@ -95,7 +91,7 @@ public class LessonController : ControllerBase
     }
 
     [HttpGet("user")]
-    public async Task<ActionResult<List<LessonDto>>> LessonsForUser()
+    public async Task<ActionResult<List<LessonWithStartEnd>>> LessonsForUser()
     {
         int claim = _tokenService.GetIdClaimFromHeaderValue(Request);
 
@@ -103,17 +99,7 @@ public class LessonController : ControllerBase
         {
             return BadRequest();
         }
-
-        try
-        {
-            List<LessonDto> allLessonsForUserId = await _lessonService.AllLessonsForUserIdAsync(claim);
-
-            // List<LessonDto> lessonDtos = _lessonService.LessonsToLessonDtos(allLessonsForUserId);
-            return allLessonsForUserId;
-        }
-        catch
-        {
-            return BadRequest("Not found");
-        }
+        List<LessonWithStartEnd> allLessonsForUserId = await _lessonService.AllLessonsForUserIdAsync(claim);
+        return allLessonsForUserId;
     }
 }

--- a/Api/DataTransfer/Lessons/LessonWithStartEnd.cs
+++ b/Api/DataTransfer/Lessons/LessonWithStartEnd.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Routing.Template;
+using TeamFive.DataTransfer.Users;
+using TeamFive.Models;
+
+namespace TeamFive.DataTransfer.Lessons;
+
+public class LessonWithStartEnd
+{
+    public int LessonId { get; set; }
+    public DateTime Start { get; set; }
+    public DateTime End { get; set; }
+    public UserDto Teacher {get; set;}
+    public UserDto Student {get; set;}
+    public InstrumentDto Instrument {get; set;}
+
+    public LessonWithStartEnd(Lesson lesson, UserDto teacher, UserDto student, InstrumentDto instrument)
+    {
+        LessonId = lesson.LessonId;
+        Start = lesson.BookingDate;
+        End = lesson.BookingDate.AddMinutes(lesson.DurationMinutes);
+        Teacher = teacher;
+        Student = student;
+        Instrument = instrument;
+    }
+}

--- a/Api/Models/Instrument.cs
+++ b/Api/Models/Instrument.cs
@@ -13,7 +13,6 @@ public class Instrument : BaseEntity
     public string? ImageUrl { get; set; }
 
     // Associations
-    [JsonIgnore]
     public virtual ICollection<Lesson> Lessons { get; set; } = new List<Lesson>();
     public virtual ICollection<UserInstrument> UserInstruments { get; set; } = new List<UserInstrument>();
 }

--- a/Api/Services/Lessons/ILessonService.cs
+++ b/Api/Services/Lessons/ILessonService.cs
@@ -9,6 +9,6 @@ public interface ILessonService
     Task<List<Lesson>> AllLessons();
     Task<LessonDto?> OneLessonAsync(int lessonId);
     Task<LessonDto?> CreateLessonAsync(Lesson lesson);
-    Task<List<LessonDto>> AllLessonsForUserIdAsync(int userId);
+    Task<List<LessonWithStartEnd>> AllLessonsForUserIdAsync(int userId);
     // List<LessonDto> LessonsToLessonDtos(List<LessonDto> lessons);
 }

--- a/Api/Services/Lessons/LessonService.cs
+++ b/Api/Services/Lessons/LessonService.cs
@@ -66,9 +66,9 @@ public class LessonService : ILessonService
       User? student = await _context.Users.FirstOrDefaultAsync(u=>u.UserId==lesson.StudentId);
       Instrument? instrument = await _context.Instruments.FirstOrDefaultAsync(i=>i.InstrumentId ==lesson.InstrumentId);
 
-      UserDto? lessonTeacherDto = new(teacher);
-      UserDto? lessonStudentDto = new(student);
-      InstrumentDto? lessonInstrumentDto = new(instrument);
+      UserDto? lessonTeacherDto = new(teacher!);
+      UserDto? lessonStudentDto = new(student!);
+      InstrumentDto? lessonInstrumentDto = new(instrument!);
       LessonDto createdLessonDto = new LessonDto(lesson, lessonTeacherDto, lessonStudentDto, lessonInstrumentDto);
 
       if(creationResult > 0)
@@ -82,18 +82,18 @@ public class LessonService : ILessonService
       }
     }
 
-    public async Task<List<LessonDto>> AllLessonsForUserIdAsync(int userId)
+    public async Task<List<LessonWithStartEnd>> AllLessonsForUserIdAsync(int userId)
     {
 
         Console.WriteLine(userId);
       try
       {
-            List<LessonDto> lessonsForUser = await _context.Lessons
+            List<LessonWithStartEnd> lessonsForUser = await _context.Lessons
                 .Include(l => l.Instrument)
                 .Include(l => l.Teacher)
                 .Include(l => l.Student)
                 .Where(l => l.TeacherId == userId)
-                .Select(lesson => new LessonDto(lesson, new UserDto(lesson.Student!), new UserDto(lesson.Teacher!), new InstrumentDto(lesson.Instrument!)))
+                .Select(lesson => new LessonWithStartEnd(lesson, new UserDto(lesson.Student!), new UserDto(lesson.Teacher!), new InstrumentDto(lesson.Instrument!)))
                 .ToListAsync();
 
         return lessonsForUser;


### PR DESCRIPTION
### Completes

Lesson list returned by UserId now have Start and End times

### Checklist

- [ ] I have tested my changes.
- [ ] I have updated the documentation if necessary.

## What Did you do to test this feature?

Fetched all lessons for userId 1 and got this:

```JS
[
    {
        "lessonId": 1,
        "start": "2023-11-20T18:39:00",
        "end": "2023-11-20T19:01:00",
        "teacher": {
            "userId": 50,
            "firstName": "Rosalia",
            "lastName": "Turner",
            "email": "rosalia.turner@email.com"
        },
        "student": {
            "userId": 1,
            "firstName": "Charlene",
            "lastName": "Dibbert",
            "email": "charlene.dibbert@email.com"
        },
        "instrument": {
            "instrumentId": 2,
            "name": "Guitar",
            "family": "String"
        }
    },
    {
        "lessonId": 3,
        "start": "2023-11-20T18:39:00",
        "end": "2023-11-20T19:01:00",
        "teacher": {
            "userId": 50,
            "firstName": "Rosalia",
            "lastName": "Turner",
            "email": "rosalia.turner@email.com"
        },
        "student": {
            "userId": 1,
            "firstName": "Charlene",
            "lastName": "Dibbert",
            "email": "charlene.dibbert@email.com"
        },
        "instrument": {
            "instrumentId": 2,
            "name": "Guitar",
            "family": "String"
        }
    }
]
```