### PR TITLE
Added new hook to call API to return data instead of update state

### DIFF
--- a/Client/src/Components/Calendar.jsx
+++ b/Client/src/Components/Calendar.jsx
@@ -2,7 +2,6 @@ import { useState, useRef, useEffect } from 'react';
 import { DayPilot, DayPilotCalendar, DayPilotNavigator } from "@daypilot/daypilot-lite-react";
 import useLocalStorage from "../Hooks/useLocalStorage";
 import useApi from "../Hooks/useApi";
-import axios from "axios";
 
 const styles = {
   wrap: {
@@ -17,6 +16,7 @@ const styles = {
 };
 
 const Calendar = () => {
+  const [loading, setLoading] = useState(true);
   const [credentials, setCredentials] = useLocalStorage("credentials", {});
   const url = "/api/lesson/user";
 
@@ -66,8 +66,16 @@ const Calendar = () => {
         {
           text: "Cancel Lesson",
           onClick: async args => {
+            let id = args.source.id();
             const dp = calendarRef.current.control;
-            dp.events.remove(args.source);
+            try {
+              // Current problem: this is affecting the data variable from the useApi() hook, causing the calendar to display the wrong data.
+              handleSubmit(`/api/lesson/${id}/delete`, {}, "POST");
+              dp.events.remove(args.source);
+              console.log("Deleted successfully.")
+            } catch (err) {
+              console.log(err);
+            }
           },
         },
         // {
@@ -125,7 +133,16 @@ const Calendar = () => {
       //     });
       //   }
       // }
-    }
+    },
+    // onEventDeleted: async (args) => {
+    //   let id = args.e.id();
+    //   try {
+    //     await axios.delete(`/api/lesson/${id}`);
+    //     console.log("Deleted successfully.")
+    //   } catch (err) {
+    //     console.log(err);
+    //   }
+    // }
   });
 
   useEffect(() => {
@@ -137,7 +154,9 @@ const Calendar = () => {
     console.log(data);
     let events;
 
-    if (data) {
+    if (data && data.length > 0) {
+      // Thinking of a way to implement a loading animation while still rendering calendarRef.current
+      setLoading(false);
       events = data.map(lessonsToEvents);
     }
 

--- a/Client/src/Hooks/useApi.jsx
+++ b/Client/src/Hooks/useApi.jsx
@@ -2,6 +2,9 @@ import { useState } from 'react';
 import axios from 'axios';
 import useLocalStorage from "./useLocalStorage";
 
+// useApi() for updatable data state (best with only one unique repeatable request to API)
+// useApiWithReturn() for single-use returns (if you have multiple unique calls to API)
+
 const useApi = () => {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(false);

--- a/Client/src/Hooks/useApiWithReturn.jsx
+++ b/Client/src/Hooks/useApiWithReturn.jsx
@@ -1,0 +1,69 @@
+import axios from 'axios';
+import useLocalStorage from "./useLocalStorage";
+
+// useApi() for updatable data state (best with only one unique repeatable request to API)
+// useApiWithReturn() for single-use return statements (if you have multiple unique calls to API)
+
+const useApiWithReturn = () => {
+  const [credentials, setCredentials] = useLocalStorage("credentials", {});
+
+  const getHeaders = (accessToken) => ({
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/json",
+  });
+
+  const fetchData = async (givenUrl, bodyData, givenMethod, accessToken) => {
+    const headers = getHeaders(accessToken);
+    const config = {
+      method: givenMethod,
+      url: givenUrl,
+      headers: headers,
+      data: bodyData,
+    };
+    return await axios(config);
+  };
+
+  const refreshTokenAndRetry = async (originalConfig) => {
+    const refreshToken = credentials["refreshToken"];
+    const refreshResponse = await axios.post("/api/auth/refresh", {
+        token: refreshToken,
+    });
+    const accessToken = refreshResponse.data.accessToken;
+    const newRefreshToken = refreshResponse.data.refreshToken
+    setCredentials({...credentials,"accessToken":accessToken, "refreshToken":newRefreshToken});
+    originalConfig.headers["Authorization"] = `Bearer ${accessToken}`;
+
+    return axios(originalConfig);
+  };
+
+  const fetchDataWrapper = async (givenUrl, bodyData, givenMethod) => {
+    try {
+      const result = await fetchData(givenUrl, bodyData, givenMethod, credentials["accessToken"] || "");
+      return result.data;
+    } catch (err) {
+      if (err.response && err.response.status === 401) {
+        try {
+          const retryResult = await refreshTokenAndRetry({
+            method: givenMethod,
+            url: givenUrl,
+            headers: getHeaders(credentials["accessToken"]),
+            data: bodyData
+          });
+          return retryResult.data;
+        } catch (refreshError) {
+          return refreshError;
+        }
+      } else {
+        return err;
+      }
+    }
+  };
+
+  const handleSubmit = (givenUrl, givenData, givenMethod) => {
+    return fetchDataWrapper(givenUrl, givenData, givenMethod);
+  };
+
+  return { handleSubmit };
+};
+
+export default useApiWithReturn;


### PR DESCRIPTION
### Completes

Added a separate hook similar to useApi() that checks accessTokens and returns data. The difference between useApiWithReturn and useApi is that the former directly returns the result/error, while the latter updates the state of data and error variables.

### Checklist

- [x] I have tested my changes.
- [ ] I have updated the documentation if necessary.

## What Did you do to test this feature?

After adding the hook to the calendar component, I was able to successfully delete lessons from the calendar without affecting the rest of the data state.
